### PR TITLE
fix: propagate timeout error to user land

### DIFF
--- a/src/web_client/crequest.ts
+++ b/src/web_client/crequest.ts
@@ -7,12 +7,21 @@ export class CRequest {
 
   private readonly _headers: Record<string, string>;
 
-  public constructor(method: string, uri: string, body: string, headers: Record<string, string>) {
+  private readonly _timeout?: number;
+
+  public constructor(
+    method: string,
+    uri: string,
+    body: string,
+    headers: Record<string, string>,
+    timeout?: number,
+  ) {
     this._method = method;
     this._uri = uri;
     this._body = body;
     const map = new Map([...Object.entries(this.defaultHeaders()), ...Object.entries(headers)]);
     this._headers = Object.fromEntries(map);
+    this._timeout = timeout;
   }
 
   public getMethod(): string {
@@ -29,6 +38,10 @@ export class CRequest {
 
   public getHeaders(): Record<string, string> {
     return this._headers;
+  }
+
+  public getTimeout(): number | undefined {
+    return this._timeout;
   }
 
   public defaultHeaders(): {
@@ -48,12 +61,14 @@ export class CRequest {
     uri: string;
     body: string;
     headers: Record<string, string>;
+    timeout?: number;
   } {
     return {
       method: this._method,
       uri: this._uri,
       body: this._body,
       headers: this._headers,
+      timeout: this._timeout,
     };
   }
 }

--- a/src/web_client/cresponse.ts
+++ b/src/web_client/cresponse.ts
@@ -5,10 +5,20 @@ export class CResponse {
 
   private readonly _headers: Record<string, string>;
 
+  static TIMEOUT_CODE = 1;
+
   public constructor(statuscode: number, body: string, headers: Record<string, string> = {}) {
     this._statusCode = statuscode;
     this._body = body;
     this._headers = headers;
+  }
+
+  static timeout(milliseconds?: number): CResponse {
+    return new CResponse(
+      CResponse.TIMEOUT_CODE,
+      `Timeout after ${milliseconds ?? 'unknown'} ms`,
+      {},
+    );
   }
 
   public getStatusCode(): number {
@@ -25,6 +35,10 @@ export class CResponse {
 
   public isEmpty(): boolean {
     return this._body === '';
+  }
+
+  public statusCodeIsTimeoutError(): boolean {
+    return this._statusCode === CResponse.TIMEOUT_CODE;
   }
 
   public statusCodeIsClientError(): boolean {

--- a/src/web_client/cresponse.ts
+++ b/src/web_client/cresponse.ts
@@ -5,7 +5,7 @@ export class CResponse {
 
   private readonly _headers: Record<string, string>;
 
-  static TIMEOUT_CODE = 1;
+  private static TIMEOUT_CODE = 1;
 
   public constructor(statuscode: number, body: string, headers: Record<string, string> = {}) {
     this._statusCode = statuscode;

--- a/src/web_client/exceptions/http_timeout_error.ts
+++ b/src/web_client/exceptions/http_timeout_error.ts
@@ -1,0 +1,3 @@
+import { WebClientException } from './web_client_exception.js';
+
+export class HttpTimeoutError extends WebClientException {}

--- a/src/web_client/https_web_client.ts
+++ b/src/web_client/https_web_client.ts
@@ -66,12 +66,15 @@ export class HttpsWebClient implements WebClientInterface {
 
       clientRequest.on('timeout', () => {
         clientRequest.destroy();
-        const errorResponse = CResponse.timeout(this._timeout);
 
         const rejectReason =
           this._timeout === undefined
             ? new Error('Request time out')
-            : new WebClientException('Request time out', request, errorResponse);
+            : new WebClientException(
+              'Request time out',
+              request,
+              CResponse.timeout(this._timeout)
+            );
 
         reject(rejectReason);
       });

--- a/src/web_client/https_web_client.ts
+++ b/src/web_client/https_web_client.ts
@@ -10,9 +10,16 @@ export class HttpsWebClient implements WebClientInterface {
 
   private readonly _fireResponseClosure?: CallableFunction;
 
-  public constructor(onFireRequest?: CallableFunction, onFireResponse?: CallableFunction) {
+  private readonly _timeout?: number;
+
+  public constructor(
+    onFireRequest?: CallableFunction,
+    onFireResponse?: CallableFunction,
+    timeout?: number,
+  ) {
     this._fireRequestClosure = onFireRequest;
     this._fireResponseClosure = onFireResponse;
+    this._timeout = timeout;
   }
 
   public fireRequest(request: CRequest): void {
@@ -31,6 +38,7 @@ export class HttpsWebClient implements WebClientInterface {
     const options = {
       method: request.getMethod(),
       headers: request.getHeaders(),
+      timeout: this._timeout,
     };
 
     return new Promise((resolve, reject) => {
@@ -58,7 +66,8 @@ export class HttpsWebClient implements WebClientInterface {
 
       clientRequest.on('timeout', () => {
         clientRequest.destroy();
-        reject(new Error('Request time out'));
+        const errorResponse = CResponse.timeout(this._timeout);
+        reject(new WebClientException('Request time out', request, errorResponse));
       });
 
       clientRequest.write(request.getBody());

--- a/src/web_client/https_web_client.ts
+++ b/src/web_client/https_web_client.ts
@@ -70,11 +70,7 @@ export class HttpsWebClient implements WebClientInterface {
         const rejectReason =
           this._timeout === undefined
             ? new Error('Request time out')
-            : new WebClientException(
-              'Request time out',
-              request,
-              CResponse.timeout(this._timeout)
-            );
+            : new WebClientException('Request time out', request, CResponse.timeout(this._timeout));
 
         reject(rejectReason);
       });

--- a/src/web_client/https_web_client.ts
+++ b/src/web_client/https_web_client.ts
@@ -38,7 +38,7 @@ export class HttpsWebClient implements WebClientInterface {
     const options = {
       method: request.getMethod(),
       headers: request.getHeaders(),
-      timeout: this._timeout,
+      timeout: this._timeout ?? request.getTimeout() ?? undefined,
     };
 
     return new Promise((resolve, reject) => {
@@ -67,7 +67,13 @@ export class HttpsWebClient implements WebClientInterface {
       clientRequest.on('timeout', () => {
         clientRequest.destroy();
         const errorResponse = CResponse.timeout(this._timeout);
-        reject(new WebClientException('Request time out', request, errorResponse));
+
+        const rejectReason =
+          this._timeout === undefined
+            ? new Error('Request time out')
+            : new WebClientException('Request time out', request, errorResponse);
+
+        reject(rejectReason);
       });
 
       clientRequest.write(request.getBody());

--- a/tests/unit/internal/service_consumer.spec.ts
+++ b/tests/unit/internal/service_consumer.spec.ts
@@ -6,7 +6,7 @@ import { CRequest } from '#src/web_client/crequest';
 import { CResponse } from '#src/web_client/cresponse';
 import { HttpServerError } from '#src/web_client/exceptions/http_server_error';
 import { SoapFaultError } from '#src/web_client/exceptions/soap_fault_error';
-import { WebClientException } from '#src/web_client/exceptions/web_client_exception';
+import { type WebClientException } from '#src/web_client/exceptions/web_client_exception';
 import { type WebClientInterface } from '#src/web_client/web_client_interface';
 import { fileContents } from '#tests/test_utils';
 import { HttpTimeoutError } from '#src/web_client/exceptions/http_timeout_error';

--- a/tests/unit/internal/service_consumer.spec.ts
+++ b/tests/unit/internal/service_consumer.spec.ts
@@ -9,6 +9,7 @@ import { SoapFaultError } from '#src/web_client/exceptions/soap_fault_error';
 import { WebClientException } from '#src/web_client/exceptions/web_client_exception';
 import { type WebClientInterface } from '#src/web_client/web_client_interface';
 import { fileContents } from '#tests/test_utils';
+import { HttpTimeoutError } from '#src/web_client/exceptions/http_timeout_error';
 
 describe('service consumer', () => {
   let webClient: MockProxy<WebClientInterface>;
@@ -142,5 +143,18 @@ describe('service consumer', () => {
 
     expect(result).toThrow(HttpServerError);
     expect(result).toThrow('Unexpected empty response from server');
+  });
+
+  test('check error on timeout', () => {
+    const request = new CRequest('POST', 'uri', 'body', {});
+    const response = CResponse.timeout();
+    const consumer = new ServiceConsumer();
+
+    const result = (): void => {
+      consumer.checkErrors(request, response);
+    };
+
+    expect(result).toThrow(HttpTimeoutError);
+    expect(result).toThrow(`Unexpected timeout error: ${response.getBody()}`);
   });
 });

--- a/tests/unit/web_client/exceptions/http_timeout_error.spec.ts
+++ b/tests/unit/web_client/exceptions/http_timeout_error.spec.ts
@@ -1,0 +1,16 @@
+import { CRequest } from '#src/web_client/crequest';
+import { CResponse } from '#src/web_client/cresponse';
+import { HttpTimeoutError } from '#src/web_client/exceptions/http_timeout_error';
+import { WebClientException } from '#src/web_client/exceptions/web_client_exception';
+
+describe('http timeout error', () => {
+  test('instance of webclientexception', () => {
+    const exception = new HttpTimeoutError(
+      'message',
+      new CRequest('GET', 'unknown://invalid uri/', '', {}),
+      CResponse.timeout(),
+    );
+
+    expect(exception).toBeInstanceOf(WebClientException);
+  });
+});

--- a/tests/unit/web_client/https_web_client.spec.ts
+++ b/tests/unit/web_client/https_web_client.spec.ts
@@ -9,6 +9,12 @@ describe('https web client test', () => {
     await expect(() => webClient.call(request)).rejects.toThrowError('Invalid URL');
   });
 
+  test('call throws timeout', async () => {
+    const request = new CRequest('GET', 'https://localhost', '', {});
+    const webClient = new HttpsWebClient(undefined, undefined, 1);
+    await expect(() => webClient.call(request)).rejects.toThrowError('Request time out');
+  });
+
   test('fire request', () => {
     const captured: CRequest[] = [];
     const observer = (requestCaptured: CRequest): void => {

--- a/tests/unit/web_client/https_web_client.spec.ts
+++ b/tests/unit/web_client/https_web_client.spec.ts
@@ -1,5 +1,6 @@
 import { CRequest } from '#src/web_client/crequest';
 import { CResponse } from '#src/web_client/cresponse';
+import { WebClientException } from '#src/web_client/exceptions/web_client_exception';
 import { HttpsWebClient } from '#src/web_client/https_web_client';
 
 describe('https web client test', () => {
@@ -13,6 +14,14 @@ describe('https web client test', () => {
     const request = new CRequest('GET', 'https://localhost', '', {});
     const webClient = new HttpsWebClient(undefined, undefined, 1);
     await expect(() => webClient.call(request)).rejects.toThrowError('Request time out');
+    await expect(() => webClient.call(request)).rejects.toBeInstanceOf(WebClientException);
+  });
+
+  test('call keeps existing timeout behavior', async () => {
+    const request = new CRequest('GET', 'https://localhost', '', {}, 1);
+    const webClient = new HttpsWebClient(undefined, undefined);
+    await expect(() => webClient.call(request)).rejects.toBeInstanceOf(Error);
+    await expect(() => webClient.call(request)).rejects.not.toBeInstanceOf(WebClientException);
   });
 
   test('fire request', () => {


### PR DESCRIPTION
Allow user via HttpTimeoutError and allow user to define a custom timeout

### 🔗 Enlace de issue

#32

### ❓ Tipo de cambio

- [x] 🐞 Corrección de Bug (un cambio continuo que soluciona un problema)
- [ ] 👌 Mejora (mejorar una funcionalidad existente como el rendimiento)
- [ ] ✨ Nueva característica (un cambio continuo que agrega funcionalidad)
- [x] ⚠️ Breaking change (corrección o característica que haría que la funcionalidad existente cambiara)

### 📚 Descripción

Resuelve #32 permitiendo que se lanze una excepcion cuando sucede un Timeout en la peticion de verificacion de una peticion. 

### 📝 Lista de Verificación

- [x] He vinculado un problema o discusión.
- [ ] He actualizado la documentación en consecuencia.
